### PR TITLE
Fixed #45

### DIFF
--- a/src/main/java/edu/vanderbilt/accre/laurelin/array/JaggedArrayPrep.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/array/JaggedArrayPrep.java
@@ -42,7 +42,7 @@ public class JaggedArrayPrep extends Array {
 
         int itemstart = this.offsets.get(start);
         int itemstop = this.offsets.get(stop);
-        return this.content.clip(itemstart, itemstop);
+        return new JaggedArrayPrep(this.interpretation, stop - start, (PrimitiveArray.Int4)this.counts.clip(start, stop), this.content.clip(itemstart, itemstop));
     }
 
     public Object toArray(boolean bigEndian) {

--- a/src/test/java/edu/vanderbilt/accre/array/ArrayBoundsTest.java
+++ b/src/test/java/edu/vanderbilt/accre/array/ArrayBoundsTest.java
@@ -1,0 +1,34 @@
+package edu.vanderbilt.accre.array;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import edu.vanderbilt.accre.laurelin.array.ArrayBuilder;
+import edu.vanderbilt.accre.laurelin.array.RawArray;
+import edu.vanderbilt.accre.laurelin.interpretation.AsDtype;
+import edu.vanderbilt.accre.laurelin.interpretation.Interpretation;
+
+public class ArrayBoundsTest {
+
+    @Test
+    public void testNanoBaskets() {
+        long[] basketEntryOffsets = {0, 1000, 4266, 8532};
+        class DummyBranchCallback implements ArrayBuilder.GetBasket {
+            @Override
+            public ArrayBuilder.BasketKey basketkey(int basketid) {
+                return new ArrayBuilder.BasketKey(0, 2 * (int)basketEntryOffsets[basketid + 1], (int) (2 * (basketEntryOffsets[basketid + 1] - basketEntryOffsets[basketid])));
+            }
+
+            @Override
+            public RawArray dataWithoutKey(int basketid) {
+                return new RawArray(ByteBuffer.allocate(1000090));
+            }
+        }
+
+        Interpretation interpretation = new AsDtype(AsDtype.Dtype.UINT2);
+        ArrayBuilder builder0 = new ArrayBuilder(new DummyBranchCallback(), interpretation, basketEntryOffsets, null, 0, 1000);
+        ArrayBuilder builder1 = new ArrayBuilder(new DummyBranchCallback(), interpretation, basketEntryOffsets, null, 1000, 4266);
+    }
+
+}

--- a/src/test/java/edu/vanderbilt/accre/array/ArrayBoundsTest.java
+++ b/src/test/java/edu/vanderbilt/accre/array/ArrayBoundsTest.java
@@ -9,6 +9,24 @@ import edu.vanderbilt.accre.laurelin.array.RawArray;
 import edu.vanderbilt.accre.laurelin.interpretation.AsDtype;
 import edu.vanderbilt.accre.laurelin.interpretation.Interpretation;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Arrays;
+import edu.vanderbilt.accre.laurelin.Cache;
+import edu.vanderbilt.accre.laurelin.array.ArrayBuilder;
+import edu.vanderbilt.accre.laurelin.interpretation.AsDtype;
+import edu.vanderbilt.accre.laurelin.interpretation.AsJagged;
+import edu.vanderbilt.accre.laurelin.interpretation.Interpretation;
+import edu.vanderbilt.accre.laurelin.root_proxy.TBasket;
+import edu.vanderbilt.accre.laurelin.root_proxy.TBranch;
+import edu.vanderbilt.accre.laurelin.root_proxy.TFile;
+import edu.vanderbilt.accre.laurelin.root_proxy.TLeaf;
+import edu.vanderbilt.accre.laurelin.root_proxy.TTree;
+import edu.vanderbilt.accre.laurelin.spark_ttree.SlimTBranch;
+import edu.vanderbilt.accre.laurelin.array.Array;
+import edu.vanderbilt.accre.laurelin.array.JaggedArrayPrep;
+
 public class ArrayBoundsTest {
 
     @Test
@@ -32,6 +50,31 @@ public class ArrayBoundsTest {
         Interpretation interpretation = new AsDtype(AsDtype.Dtype.UINT2);
         ArrayBuilder builder0 = new ArrayBuilder(new DummyBranchCallback(), interpretation, basketEntryOffsets, null, 0, 1000);
         ArrayBuilder builder1 = new ArrayBuilder(new DummyBranchCallback(), interpretation, basketEntryOffsets, null, 1000, 4266);
+    }
+
+    private TTree getTestTree() throws IOException {
+        String testPath = "nano_19.root";
+        String testTree = "Events";
+        File f = new File(testPath);
+        TFile currFile = TFile.getFromFile(testPath);
+        return new TTree(currFile.getProxy(testTree), currFile);
+    }
+
+    @Test
+    public void testNano19() throws IOException {
+        TTree currTree = getTestTree();
+        List<TBranch> branches = currTree.getBranches("Jet_pt");
+        TBranch branch = branches.get(0);
+        List<TBasket> baskets = branch.getBaskets();
+        Cache branchCache = new Cache();
+        SlimTBranch slimBranch = SlimTBranch.getFromTBranch(branch);
+        ArrayBuilder.GetBasket getbasket = slimBranch.getArrayBranchCallback(branchCache);
+        long []basketEntryOffsets = slimBranch.getBasketEntryOffsets();
+        Interpretation interp = new AsJagged(new AsDtype(AsDtype.Dtype.FLOAT4));
+        ArrayBuilder builder = new ArrayBuilder(getbasket, interp, basketEntryOffsets, null, 0, 50069);
+        JaggedArrayPrep testarray = (JaggedArrayPrep)builder.getArray(0, 10);
+        System.out.println(Arrays.toString((int[])(testarray.counts().toArray(true))));
+        System.out.println(Arrays.toString((float[])(testarray.content().toArray(true))));
     }
 
 }

--- a/src/test/java/edu/vanderbilt/accre/array/ArrayBoundsTest.java
+++ b/src/test/java/edu/vanderbilt/accre/array/ArrayBoundsTest.java
@@ -17,12 +17,15 @@ public class ArrayBoundsTest {
         class DummyBranchCallback implements ArrayBuilder.GetBasket {
             @Override
             public ArrayBuilder.BasketKey basketkey(int basketid) {
-                return new ArrayBuilder.BasketKey(0, 2 * (int)basketEntryOffsets[basketid + 1], (int) (2 * (basketEntryOffsets[basketid + 1] - basketEntryOffsets[basketid])));
+                int keylen = 0;
+                int last = (int) (2 * (basketEntryOffsets[basketid + 1] - basketEntryOffsets[basketid]));
+                int objlen = last;
+                return new ArrayBuilder.BasketKey(keylen, last, objlen);
             }
 
             @Override
             public RawArray dataWithoutKey(int basketid) {
-                return new RawArray(ByteBuffer.allocate(1000090));
+                return new RawArray(ByteBuffer.allocate((int) (2 * (basketEntryOffsets[basketid + 1] - basketEntryOffsets[basketid]))));
             }
         }
 

--- a/src/test/java/edu/vanderbilt/accre/array/package-info.java
+++ b/src/test/java/edu/vanderbilt/accre/array/package-info.java
@@ -1,0 +1,1 @@
+package edu.vanderbilt.accre.array;


### PR DESCRIPTION
This was actually two bugs, one mine, one yours. (Or, more specifically, a miscommunication between you and me.)

First for my bug: in the development of uproot, `i` and `j` as basket indexes "acquired" a meaning as I worked it out. `i` is an absolute basket number—if a branch has 12 baskets, `0 <= i < 12`. `j` is a basket index for the subrange of entries the user asks for with `entrystart` and `entrystop`—if the desired entries does not include some baskets, uproot doesn't read their keys (which likely involves touching cold disk pages). Perhaps the desired entries are entirely within baskets `i ∈ [5, 10)`, excluding baskets `[0, 5) ∪ [10, 12)`. Then `0 <= j < 5` with `j = i - 5`.

If the user asks for `entrystart=0` (or any entry in the first basket) then none of this matters: `i == j`. The uproot testing suite is full of torturous `entrystart/entrystop` tests, but we haven't stressed that part of laurelin in its tests. The minimal reproducer in issue #45 triggers a bug in the translation of this logic from uproot to laurelin. It's not a simple copy-paste: I now have to make a distinction in the laurelin code between `basket_entryoffset`, indexed by `j`, and `basketEntryOffsets`, indexed by `i`, because the first is a local variable and the second is a class instance attribute in uproot, but I couldn't do the same because I can't define a function inside a function in Java (_idiomatically_—I know I can define a new class inline, but blah).

Short story, I fixed it, and I put line number links to the original uproot for this one at least.

The second "bug" is illustrated in my modification of the test. I think there's a miscommunication about what `ArrayBuilder` is supposed to do. It's not supposed to be per-basket (as the test is using it), it's supposed to be per-branch. `ArrayBuilder` uses the callback to ask for the baskets it needs to build an array for the branch that can span many baskets. The only reason you'd pass an `entrystart` or `entrystop` to its constructor different from `0` and the total number of entries (of the whole tree) is if you don't want to get them all. You _do not have to_ ask for basket ranges individually—all that logic in `ArrayBuilder` that was translated from uproot is providing an abstraction over baskets so that you can think about a branch as a single array (and the return value is a _contiguous_ array).

Also, you got the `BasketKey` values wrong: `fKeylen` is the number of bytes in the basket header, which can be zero in an artificial example, `fLast` is the number of bytes in the "content", and `fObjlen` is the number of bytes in the "content" plus "offsets" plus 8 if there are any "offsets". So for a non-jagged array, `fLast == fObjlen` (and I use that to detect jagged arrays). This is a _basket_ key; it's not cumulative. It's possible that this error was just introduced when making the minimally reproducing example, since a well-formed ROOT file would set these values correctly.