### PR TITLE
Trim partition info transmitted to executors

### DIFF
--- a/src/main/java/edu/vanderbilt/accre/laurelin/Root.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/Root.java
@@ -406,7 +406,7 @@ public class Root implements DataSourceV2, ReadSupport, DataSourceRegister {
                         for (Entry<String, SlimTBranch> e: slimBranches.entrySet()) {
                             trimmedSlimBranches.put(e.getKey(), e.getValue().copyAndTrim(partitionStart, partitionEnd));
                         }
-                        ret.add(new TTreeDataSourceV2Partition(schema, basketCacheFactory, partitionStart, partitionEnd, slimBranches, threadCount, profileData, pid));
+                        ret.add(new TTreeDataSourceV2Partition(schema, basketCacheFactory, partitionStart, partitionEnd, trimmedSlimBranches, threadCount, profileData, pid));
                     }
                     if (ret.size() == 0) {
                         // Only one basket?

--- a/src/main/java/edu/vanderbilt/accre/laurelin/root_proxy/TBranch.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/root_proxy/TBranch.java
@@ -452,10 +452,10 @@ public class TBranch {
         for (int i = 0; i < basketEntryOffsets.length - 1; i += 1) {
             basketBuilder = basketBuilder.put(Range.closed(basketEntryOffsets[i], basketEntryOffsets[i + 1] - 1), i);
         }
-        ImmutableRangeMap<Long, Integer> rangeToBasketIDMap = basketBuilder.build();
-        Entry<Range<Long>, Integer> low = rangeToBasketIDMap.getEntry(entrystart);
-        Entry<Range<Long>, Integer> high = rangeToBasketIDMap.getEntry(entrystop - 1);
+        ImmutableRangeMap<Long, Integer> tmpMap = basketBuilder.build();
+        Entry<Range<Long>, Integer> low = tmpMap.getEntry(entrystart);
+        Entry<Range<Long>, Integer> high = tmpMap.getEntry(entrystop - 1);
         Range<Long> wideRange = Range.closed(low.getKey().lowerEndpoint(), high.getKey().upperEndpoint());
-        return rangeToBasketIDMap.subRangeMap(wideRange);
+        return tmpMap.subRangeMap(wideRange);
     }
 }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranch.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranch.java
@@ -225,7 +225,6 @@ public class SlimTBranch implements Serializable, SlimTBranchInterface {
         private static final Logger logger = LogManager.getLogger();
 
         private static final long serialVersionUID = 1L;
-        private SlimTBranchInterface branch;
         private long offset;
         private Cursor payload;
 
@@ -243,13 +242,12 @@ public class SlimTBranch implements Serializable, SlimTBranchInterface {
         private byte fHeaderOnly;
         private Cursor headerEnd;
 
-        private SlimTBasket(SlimTBranchInterface slimBranch, long offset) {
-            branch = slimBranch;
+        private SlimTBasket(long offset) {
             this.offset = offset;
         }
 
         public static SlimTBasket makeEagerBasket(SlimTBranchInterface branch, long offset, int compressedLen, int uncompressedLen, int keyLen, int last) {
-            SlimTBasket ret = new SlimTBasket(branch, offset);
+            SlimTBasket ret = new SlimTBasket(offset);
             ret.isPopulated = true;
             ret.compressedLen = compressedLen;
             ret.uncompressedLen = uncompressedLen;
@@ -259,7 +257,7 @@ public class SlimTBranch implements Serializable, SlimTBranchInterface {
         }
 
         public static SlimTBasket makeLazyBasket(SlimTBranchInterface branch, long offset) {
-            SlimTBasket ret = new SlimTBasket(branch, offset);
+            SlimTBasket ret = new SlimTBasket(offset);
             ret.isPopulated = false;
             return ret;
         }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranch.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranch.java
@@ -147,7 +147,6 @@ public class SlimTBranch implements Serializable, SlimTBranchInterface {
         baskets.put(idx, basket);
     }
 
-    @Override
     public String getPath() {
         return path;
     }

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranch.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranch.java
@@ -93,8 +93,7 @@ public class SlimTBranch implements Serializable, SlimTBranchInterface {
     public static SlimTBranch getFromTBranch(TBranch fatBranch) {
         SlimTBranch slimBranch = new SlimTBranch(fatBranch.getTree().getBackingFile().getFileName(), fatBranch.getBasketEntryOffsets(), fatBranch.getArrayDescriptor());
         for (int i = 0; i < fatBranch.getBasketCount(); i += 1) {
-            SlimTBasket slimBasket = SlimTBasket.makeLazyBasket(slimBranch,
-                    fatBranch.getBasketSeek()[i]);
+            SlimTBasket slimBasket = SlimTBasket.makeLazyBasket(fatBranch.getBasketSeek()[i]);
             slimBranch.addBasket(i, slimBasket);
         }
         return slimBranch;
@@ -255,7 +254,7 @@ public class SlimTBranch implements Serializable, SlimTBranchInterface {
             return ret;
         }
 
-        public static SlimTBasket makeLazyBasket(SlimTBranchInterface branch, long offset) {
+        public static SlimTBasket makeLazyBasket(long offset) {
             SlimTBasket ret = new SlimTBasket(offset);
             ret.isPopulated = false;
             return ret;

--- a/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranchInterface.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/spark_ttree/SlimTBranchInterface.java
@@ -14,8 +14,6 @@ public interface SlimTBranchInterface {
 
     SlimTBasket getBasket(int basketid);
 
-    String getPath();
-
     TBranch.ArrayDescriptor getArrayDesc();
 
     /**

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/SlimTBranchTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/SlimTBranchTest.java
@@ -2,6 +2,19 @@ package edu.vanderbilt.accre.spark_ttree;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import org.junit.Test;
 
@@ -11,7 +24,7 @@ import edu.vanderbilt.accre.laurelin.spark_ttree.SlimTBranch.SlimTBasket;
 public class SlimTBranchTest {
 
     @Test
-    public void test() {
+    public void test() throws ClassNotFoundException, IOException, NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         long[] basketEntryOffsetFull = new long[] {0, 10, 22, 30, 41};
         long[] basketEntrySeekFull = new long[] {0, 1, 2, 3};
 
@@ -33,12 +46,45 @@ public class SlimTBranchTest {
         assertEquals(22, middleOffset[2]);
         assertEquals(2, middle.getStoredBasketCount());
 
-        SlimTBranch end = full.copyAndTrim(20, 41);
+        SlimTBranch middle2 = full.copyAndTrim(10, 25);
+        Method method = middle2.getClass().getDeclaredMethod("writeReplace");
+        method.setAccessible(true);
+        SlimTBranch.SerializeStorage r = (SlimTBranch.SerializeStorage) method.invoke(middle2);
+        middle2 = roundTrip(middle2);
+        assertNotNull(r.getRangeToBasketID()[0]);
+        assertNotEquals(null, r.getRangeToBasketID()[0]);
+        long[] middleOffset2 = middle2.getBasketEntryOffsets();
+        assertEquals(10, middleOffset2[1]);
+        assertEquals(22, middleOffset2[2]);
+        assertEquals(2, middle2.getStoredBasketCount());
+
+        SlimTBranch end = roundTrip(full.copyAndTrim(20, 41));
         long[] endOffset = end.getBasketEntryOffsets();
         assertEquals(10, endOffset[1]);
         assertEquals(22, endOffset[2]);
         assertEquals(30, endOffset[3]);
         assertEquals(41, endOffset[4]);
         assertEquals(3, end.getStoredBasketCount());
+    }
+
+    public SlimTBranch roundTrip(SlimTBranch val) throws IOException, ClassNotFoundException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ByteArrayInputStream bis;
+        ObjectOutput out = null;
+        byte[] yourBytes = null;
+        out = new ObjectOutputStream(bos);
+        out.writeObject(val);
+        out.flush();
+        yourBytes = bos.toByteArray();
+        /*
+         *  This patch produces 348555 bytes serialized, ensure it doesn't
+         *  grow accidentally
+         */
+        assertTrue("Partition size too large", yourBytes.length < 349000);
+
+        System.out.println("Got length: " + yourBytes.length);
+        bis = new ByteArrayInputStream(yourBytes);
+        ObjectInput in = new ObjectInputStream(bis);
+        return (SlimTBranch) in.readObject();
     }
 }

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/SlimTBranchTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/SlimTBranchTest.java
@@ -17,7 +17,7 @@ public class SlimTBranchTest {
 
         SlimTBranch full = new SlimTBranch("none", basketEntryOffsetFull, null);
         for (int i = 0; i < basketEntrySeekFull.length; i += 1) {
-            full.addBasket(i, SlimTBasket.makeLazyBasket(full, basketEntrySeekFull[i]));
+            full.addBasket(i, SlimTBasket.makeLazyBasket(basketEntrySeekFull[i]));
         }
         assertArrayEquals(basketEntryOffsetFull, full.getBasketEntryOffsets());
         assertEquals(4, full.getStoredBasketCount());

--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeColumnVectorTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeColumnVectorTest.java
@@ -120,11 +120,6 @@ public class TTreeColumnVectorTest {
         }
 
         @Override
-        public String getPath() {
-            throw new UnsupportedOperationException("Not stubbed");
-        }
-
-        @Override
         public ArrayDescriptor getArrayDesc() {
             return desc;
         }


### PR DESCRIPTION
The previous version of making SlimTBranches slimmer didn't work right -- importantly, the TBaskets were holding references to the original SlimTBranch, meaning most of the space savings weren't actually seen. This is a WIP branch to drop the size of the branch info