### PR TITLE
Use concurrent hash map for basketCache

### DIFF
--- a/src/main/java/edu/vanderbilt/accre/laurelin/Cache.java
+++ b/src/main/java/edu/vanderbilt/accre/laurelin/Cache.java
@@ -1,25 +1,27 @@
 package edu.vanderbilt.accre.laurelin;
 
 import java.lang.ref.SoftReference;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.WeakHashMap;
 
 import edu.vanderbilt.accre.laurelin.array.RawArray;
 import edu.vanderbilt.accre.laurelin.root_proxy.ROOTFile;
 
 public class Cache {
-    WeakHashMap<ROOTFile, HashMap<Long, SoftReference<RawArray>>> cache;
+    Map<ROOTFile, Map<Long, SoftReference<RawArray>>> cache;
     int totalCount = 0;
     int hitCount = 0;
     int missCount = 0;
 
     public Cache() {
-        cache = new WeakHashMap<ROOTFile, HashMap<Long, SoftReference<RawArray>>>();
+        cache = Collections.synchronizedMap(new WeakHashMap<ROOTFile, Map<Long, SoftReference<RawArray>>>());
     }
 
     public RawArray get(ROOTFile backingFile, long offset) {
         totalCount += 1;
-        HashMap<Long, SoftReference<RawArray>> fileMap = cache.get(backingFile);
+        Map<Long, SoftReference<RawArray>> fileMap = cache.get(backingFile);
         if (fileMap == null) {
             missCount += 1;
             return null;
@@ -34,11 +36,11 @@ public class Cache {
     }
 
     public RawArray put(ROOTFile backingFile, long offset, RawArray data) {
-        HashMap<Long, SoftReference<RawArray>> fileMap = null;
+        Map<Long, SoftReference<RawArray>> fileMap = null;
         while (fileMap == null) {
             fileMap = cache.get(backingFile);
             if (fileMap == null) {
-                cache.putIfAbsent(backingFile, new HashMap<Long, SoftReference<RawArray>>());
+                cache.putIfAbsent(backingFile, Collections.synchronizedMap(new HashMap<Long, SoftReference<RawArray>>()));
             }
         }
         fileMap.put(offset, new SoftReference<RawArray>(data));


### PR DESCRIPTION
Regular hashmaps are not thread-safe, which can give occasional
explosions under contention. Wrap HashMaps in synchronizedMap
to protect them.

A future version should replace the nested keys with a complex key

Fixes #73