### PR TITLE
Don't cache reader objects

### DIFF
--- a/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
+++ b/src/test/java/edu/vanderbilt/accre/spark_ttree/TTreeDataSourceUnitTest.java
@@ -3,7 +3,6 @@ package edu.vanderbilt.accre.spark_ttree;
 import static edu.vanderbilt.accre.Helpers.getBigTestDataIfExists;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -176,54 +175,6 @@ public class TTreeDataSourceUnitTest {
         }
         return yourBytes.length;
     }
-
-    @Test
-    public void testReaderInterning() {
-        Reader reader1;
-        Reader reader2;
-        Reader reader3;
-        {
-            Map<String, String> optmap = new HashMap<String, String>();
-            optmap.put("path", "testdata/uproot-foriter.root");
-            optmap.put("tree",  "foriter");
-            DataSourceOptions opts = new DataSourceOptions(optmap);
-            Root source = new Root();
-            reader1 = (Reader) source.createReader(opts, null, true);
-        }
-
-        {
-            Map<String, String> optmap = new HashMap<String, String>();
-            optmap.put("path", "testdata/uproot-foriter.root");
-            optmap.put("tree",  "foriter");
-            DataSourceOptions opts = new DataSourceOptions(optmap);
-            Root source = new Root();
-            reader2 = (Reader) source.createReader(opts, null, true);
-        }
-        assertEquals("Should be same object", reader1, reader2);
-
-        {
-            Map<String, String> optmap = new HashMap<String, String>();
-            optmap.put("path", "testdata/all-types.root");
-            optmap.put("tree",  "Events");
-            DataSourceOptions opts = new DataSourceOptions(optmap);
-            Root source = new Root();
-            reader3 = (Reader) source.createReader(opts, null, true);
-        }
-        assertNotEquals("Should not be same object", reader2, reader3);
-        assertNotEquals("Should not be same object", reader1, reader3);
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void testReaderInterningFail() {
-        Reader reader1;
-        Map<String, String> optmap = new HashMap<String, String>();
-        optmap.put("path", "testdata/uproot-foriter.root");
-        optmap.put("tree",  "INVALID TREE");
-        DataSourceOptions opts = new DataSourceOptions(optmap);
-        Root source = new Root();
-        reader1 = (Reader) source.createReader(opts, null, true);
-    }
-
 
     @Test
     public void testMultipleBasketsForiter() throws IOException {


### PR DESCRIPTION
This caching happens at the wrong part of the object lifecycle and
screws up repeated queries with different schemas, so drop it.

Reported @ #80 